### PR TITLE
Fix segmentation fault caused by non-continuous input

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -129,8 +129,18 @@ int main(int argc, char *argv[]){
         // $ parec --format=s16 --rate=16000 --channels=1 --latency-ms=100 | ./main - /path/to/model.april
 
         char data[BUFFER_SIZE];
+        ssize_t r;
         for(;;){
-            size_t r = read(STDIN_FILENO, &data[r], BUFFER_SIZE - r);
+            r = read(STDIN_FILENO, data, BUFFER_SIZE);
+            
+            if (r == -1) {
+                aas_flush(session);
+                break;
+            } else
+            if (r <= 0) {
+                continue;
+            }
+            
             aas_feed_pcm16(session, (short *)data, r/2);
         }
     } else if (argv[1][0] == '?' && argv[1][1] == 0) {


### PR DESCRIPTION
I had issues to pipe parec or arecord into it. The output I got always looked like this:
```
Model name: AprilV0
Model desc: No description added.
Model lang: en-us
Model samplerate: 16000

-  I
- 
Segmentation fault (core dumped)
```

So I looked into the code from the example.cpp and I think it was either trying to access memory it was not supposed to access or feeding it a data stream of length zero was invalid. Anyway I have solved the issues I had, adding a branch for reading errors as well (in case the input stream just ends for some reason).

Thanks for the development so far!