### PR TITLE
build: add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ bindings/python/build
 bindings/python/dist
 april-docs/src/csharp/html
 april-docs/src/april_asr
+/result
+/result-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 include(CheckIncludeFile)
+include(GNUInstallDirs)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-project(aprilasr)
+project(aprilasr
+        VERSION 2023.05.12
+        DESCRIPTION "aprilasr is a minimal library that provides an API for offline streaming speech-to-text applications"
+        HOMEPAGE_URL "https://github.com/abb128/april-asr")
 
 if(WIN32)
     set(CMAKE_SHARED_LIBRARY_PREFIX "lib")
@@ -107,6 +111,8 @@ set(april_sources
   src/sonic/sonic.c
 )
 
+file(GLOB_RECURSE april_headers "*.h")
+
 if(DEFINED USE_TINYCTHREAD)
     set(HAVE_C11_THREADS FALSE)
 else()
@@ -133,8 +139,24 @@ target_link_libraries(aprilasr_static ${onnx_link_libraries})
 add_library(aprilasr SHARED ${april_sources})
 target_link_libraries(aprilasr ${onnx_link_libraries})
 
+set_target_properties(aprilasr PROPERTIES PUBLIC_HEADER "${april_headers}")
+
 add_executable(main example.cpp)
 target_link_libraries(main PRIVATE aprilasr_static ${onnx_link_libraries})
 
 add_executable(srt example_srt.cpp)
 target_link_libraries(srt PRIVATE aprilasr_static ${onnx_link_libraries})
+
+install(TARGETS aprilasr
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME})
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc
+  @ONLY
+)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig
+)

--- a/aprilasr.pc.in
+++ b/aprilasr.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/@PROJECT_NAME@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Requires:
+Cflags: -I"${includedir}"
+Libs: -L"${libdir}" -l@PROJECT_NAME@

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1683408522,
+        "narHash": "sha256-9kcPh6Uxo17a3kK3XCHhcWiV1Yu1kYj22RHiymUhMkU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "897876e4c484f1e8f92009fd11b7d988a121a4e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-onnxruntime114": {
+      "locked": {
+        "lastModified": 1682978478,
+        "narHash": "sha256-rGt4RjtnKCnwbMk/Na/N5KWOyduIFj+Ig3ACEJR8nnA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c7d48290f9da479dcab26eac5db6299739c595c2",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-onnxruntime114": "nixpkgs-onnxruntime114"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "april-asr flake";
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs-onnxruntime114.url = "github:nixos/nixpkgs/c7d48290f9da479dcab26eac5db6299739c595c2";
+  };
+  outputs = {
+    self,
+    nixpkgs,
+    nixpkgs-onnxruntime114,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            # TODO: remove once https://github.com/NixOS/nixpkgs/pull/226734 is merged
+            (
+              final: prev: {
+                onnxruntime = nixpkgs-onnxruntime114.legacyPackages.${prev.system}.onnxruntime;
+              }
+            )
+          ];
+        };
+        inherit (pkgs) lib;
+        inherit (pkgs.stdenv.hostPlatform) isDarwin;
+      in {
+        packages = rec {
+          onnxruntime_1_14 =
+            if isDarwin
+            then pkgs.onnxruntime
+            else
+              (pkgs.onnxruntime.overrideAttrs
+                (final: {
+                  buildInputs = final.buildInputs ++ [pkgs.protobuf];
+                }))
+              .override {
+                pythonSupport = false;
+                useOneDNN = false;
+              };
+          april-asr = pkgs.stdenv.mkDerivation {
+            src = ./.;
+            name = "april-asr";
+
+            nativeBuildInputs = with pkgs; [
+              cmake
+              pkg-config
+            ];
+            buildInputs = [onnxruntime_1_14];
+
+            outputs = ["out" "dev"];
+
+            meta = with lib; {
+              description = "Speech-to-text library in C";
+              homepage = "https://github.com/abb128/april-asr";
+              license = licenses.gpl3;
+            };
+          };
+          default = april-asr;
+        };
+        devShells.default = pkgs.mkShell {
+          inherit (self.packages.${system}.default) buildInputs nativeBuildInputs;
+          shellHook = ''
+            export LD_LIBRARY_PATH=${self.packages.${system}.onnxruntime_1_14}/lib
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
Hi again!

This PR adds a Nix flake for this library, which would be used in the [LiveCaptions Nix flake](https://github.com/abb128/LiveCaptions/blob/main/flake.nix), so we can avoid using the `nix run ".?submodules=1"` parameter.

I had to adjust some things in the `CMakeLists.txt` (specifying where the headers are built to) and added `aprilasr.pc.in` for pkg-config, so please review those on a regular Linux system.

I'll make a second PR on LiveCaptions to consume this Flake.

---

Nix-related notes:
Since onnxruntime@1.14.1 isn't available on official nixpkgs yet, I had to do some patches to get the build to work. I'm pulling in NixOS/nixpkgs#226734 from its PR branch and handling a few errors that this PR introduces. We'd switch back to using `pkgs.onnxruntime` once that PR is merged, but this is the best way right now to use 1.14 like LiveCaptions requires.