### PR TITLE
Add SONAME for shared lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,8 @@ target_link_libraries(aprilasr_static ${onnx_link_libraries})
 add_library(aprilasr SHARED ${april_sources})
 target_link_libraries(aprilasr ${onnx_link_libraries})
 
+set_target_properties(aprilasr PROPERTIES VERSION ${CMAKE_PROJECT_VERSION}
+SOVERSION ${PROJECT_VERSION_MAJOR} )
 set_target_properties(aprilasr PROPERTIES PUBLIC_HEADER "${april_headers}")
 
 add_executable(main example.cpp)


### PR DESCRIPTION
Hi @abb128 ,
this fixes packaging issue for Alpine Linux and other distribution as the shared library does not have SONAME.

The original request can be looked up [here](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/47187#note_308111)